### PR TITLE
Update theme colors and KPI negative style

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,12 +1,12 @@
 /* Tema escuro aprimorado - Melhor contraste */
 [data-color-scheme="dark"] {
   /* Cores de fundo mais escuras */
-  --color-background: rgba(12, 12, 16, 1);
-  --color-surface: rgba(22, 22, 28, 1);
+  --color-background: rgba(5, 5, 8, 1);
+  --color-surface: rgba(18, 18, 22, 1);
   
   /* Texto com mais contraste */
-  --color-text: rgba(250, 250, 255, 1);
-  --color-text-secondary: rgba(200, 200, 210, 1);
+  --color-text: rgba(255, 255, 255, 1);
+  --color-text-secondary: rgba(220, 220, 225, 1);
   
   /* Cores primárias mais vibrantes */
   --color-primary: rgba(55, 195, 210, 1);
@@ -14,16 +14,16 @@
   --color-primary-active: rgba(75, 215, 230, 1);
   
   /* Cores secundárias com melhor contraste */
-  --color-secondary: rgba(50, 50, 65, 0.6);
-  --color-secondary-hover: rgba(60, 60, 75, 0.7);
-  --color-secondary-active: rgba(70, 70, 85, 0.8);
+  --color-secondary: rgba(65, 65, 80, 0.6);
+  --color-secondary-hover: rgba(75, 75, 90, 0.7);
+  --color-secondary-active: rgba(85, 85, 100, 0.8);
   
   /* Bordas mais visíveis */
-  --color-border: rgba(70, 70, 90, 0.5);
-  --color-card-border: rgba(70, 70, 90, 0.4);
-  --color-card-border-inner: rgba(70, 70, 90, 0.3);
-  --button-border-secondary: rgba(70, 70, 90, 0.4);
-  --color-border-secondary: rgba(70, 70, 90, 0.4);
+  --color-border: rgba(85, 85, 100, 0.5);
+  --color-card-border: rgba(85, 85, 100, 0.4);
+  --color-card-border-inner: rgba(85, 85, 100, 0.3);
+  --button-border-secondary: rgba(85, 85, 100, 0.4);
+  --color-border-secondary: rgba(85, 85, 100, 0.4);
   
   /* Cores de status mais vibrantes */
   --color-error: rgba(250, 80, 100, 1);
@@ -51,16 +51,16 @@ body {
 
 /* Melhorias de contraste para tabelas */
 table th {
-  background-color: rgba(40, 40, 50, 0.8);
+  background-color: rgba(30, 30, 40, 0.8);
   color: var(--color-text);
 }
 
 table tr:nth-child(even) {
-  background-color: rgba(30, 30, 40, 0.4);
+  background-color: rgba(20, 20, 30, 0.4);
 }
 
 table tr:hover {
-  background-color: rgba(50, 50, 65, 0.5);
+  background-color: rgba(40, 40, 55, 0.5);
 }
 
 /* Estilo para o indicador de valores manuais com melhor contraste */
@@ -77,7 +77,7 @@ table tr:hover {
 
 /* Estilo para valores negativos nos KPIs */
 .valor-negativo {
-  color: rgba(240, 75, 75, 1) !important;
+  color: rgba(255, 80, 80, 1) !important;
   font-weight: var(--font-weight-semibold);
 }
 
@@ -134,7 +134,7 @@ h1:hover .bi-icon svg {
 
 /* Melhorias para campos de entrada */
 input, select {
-  background-color: rgba(30, 30, 40, 1);
+  background-color: rgba(20, 20, 30, 1);
   color: var(--color-text);
   border: 1px solid var(--color-border);
 }


### PR DESCRIPTION
## Summary
- update dark theme variables to use near-black backgrounds
- tweak table and form colors for better contrast
- highlight negative KPI values with a brighter red

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_683f7797530883319e380f17c527c625