### PR TITLE
Fix Goiânia detalhado tab JS errors

### DIFF
--- a/goiania-detalhado.js
+++ b/goiania-detalhado.js
@@ -351,7 +351,7 @@ class GoianiaDetalhado {
       // Listar seções do local selecionado
       const local = this.dadosAgrupados.local.get(itemSelecionado);
       if (local) {
-        itens = Array.from(local.secos)
+        itens = Array.from(local.secoes)
           .map(secao => {
             const chaveCompleta = `${local.zona} > ${itemSelecionado} > ${secao}`;
             const dadosSecao = this.dadosAgrupados.secao.get(chaveCompleta);
@@ -423,7 +423,6 @@ class GoianiaDetalhado {
       }
     } else if (nivelAtual === 'secao' && itemSelecionado) {
       const chaveCompleta = this.estado.historico
-        .filter(h => h.nivel === 'local')
         .map(h => h.item)
         .concat(itemSelecionado)
         .join(' > ');


### PR DESCRIPTION
## Summary
- fix typo in section list generator
- build breadcrumb key correctly for section statistics

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fadbbafe883319c2f976e066bad70